### PR TITLE
xfsettingsd/pointers: initialize device_data pointer to NULL

### DIFF
--- a/xfsettingsd/pointers.c
+++ b/xfsettingsd/pointers.c
@@ -1,3 +1,4 @@
+
 /*
  *  Copyright (c) 2008-2011 Nick Schermer <nick@xfce.org>
  *
@@ -1040,7 +1041,7 @@ xfce_pointers_helper_restore_devices (XfcePointersHelper *helper,
     XDeviceInfo           *device_list, *device_info;
     gint                   n, ndevices;
     XDevice               *device;
-    XfcePointerDeviceData *device_data;
+    XfcePointerDeviceData *device_data = NULL;
     gchar                 *device_name;
     gchar                  prop[256];
     gboolean               right_handed;


### PR DESCRIPTION
If device_data is not initialized to NULL when declared, the code
assumes it is has a valid value (which is false when no mouse is
present) and dereferences it which leads to a crash.

Suggested-by: Cristian Prigoana cristian.prigoana@ni.com
Signed-off-by: Ioan-Adrian Ratiu adrian.ratiu@ni.com
